### PR TITLE
Add <br> tags after titles

### DIFF
--- a/src/slackmessageparser.ts
+++ b/src/slackmessageparser.ts
@@ -473,10 +473,10 @@ export class SlackMessageParser {
 						result.body += `## [${attachment.title}](${attachment.title_link})\n`;
 						const title = escapeHtml(attachment.title);
 						const link = escapeHtml(attachment.title_link);
-						result.formatted_body += `<strong><a href="${link}">${title}</a></strong>`;
+						result.formatted_body += `<strong><a href="${link}">${title}</a></strong><br>`;
 					} else {
 						result.body += `## ${attachment.title}\n`;
-						result.formatted_body += `<strong>${escapeHtml(attachment.title)}</strong>`;
+						result.formatted_body += `<strong>${escapeHtml(attachment.title)}</strong><br>`;
 					}
 				}
 				if (attachment.text) {

--- a/test/test_slackmessageparser.ts
+++ b/test/test_slackmessageparser.ts
@@ -767,7 +767,7 @@ describe("SlackMessageParser", () => {
 			} as any;
 			const ret = await messageParser.FormatMessage({} as any, event);
 			expect(ret.body).to.equal("## Foxies!\n");
-			expect(ret.formatted_body).to.equal("<p><strong>Foxies!</strong></p>");
+			expect(ret.formatted_body).to.equal("<p><strong>Foxies!</strong><br></p>");
 		});
 		it("should handle attachments with a title link", async () => {
 			const event = {
@@ -779,7 +779,7 @@ describe("SlackMessageParser", () => {
 			} as any;
 			const ret = await messageParser.FormatMessage({} as any, event);
 			expect(ret.body).to.equal("## [Foxies!](https://example.org)\n");
-			expect(ret.formatted_body).to.equal("<p><strong><a href=\"https://example.org\">Foxies!</a></strong></p>");
+			expect(ret.formatted_body).to.equal("<p><strong><a href=\"https://example.org\">Foxies!</a></strong><br></p>");
 		});
 		it("should handle attachments with text", async () => {
 			const event = {
@@ -791,6 +791,18 @@ describe("SlackMessageParser", () => {
 			const ret = await messageParser.FormatMessage({} as any, event);
 			expect(ret.body).to.equal("Foxies are _awesome_!\n");
 			expect(ret.formatted_body).to.equal("<p>Foxies are <em>awesome</em>!<br></p>");
+		});
+		it("should handle attachments with a title and text", async () => {
+			const event = {
+				text: "",
+				attachments: [{
+					title: "Foxies!",
+					text: "Foxies are _awesome_ indeed!",
+				}],
+			} as any;
+			const ret = await messageParser.FormatMessage({} as any, event);
+			expect(ret.body).to.equal("## Foxies!\nFoxies are _awesome_ indeed!\n");
+			expect(ret.formatted_body).to.equal("<p><strong>Foxies!</strong><br>Foxies are <em>awesome</em> indeed!<br></p>");
 		});
 		it("should handle attachment fields", async () => {
 			const event = {


### PR DESCRIPTION
Added an additional test because I wasn't sure if the \<br> should've
only be added when something follows after the title.