### PR TITLE
Allow more characters in channel/group/username

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "matrix-slack-parser",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matrix-slack-parser",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "A parser for matrix and discord messages to each others format",
   "main": "./lib/src/index.js",
   "scripts": {

--- a/src/slackmessageparser.ts
+++ b/src/slackmessageparser.ts
@@ -31,15 +31,15 @@ const MATRIX_TO_LINK = "https://matrix.to/#/";
 const EMOJI_SIZE = 32;
 
 const FLAG = "\x01";
-const USER_INSERT_REGEX = /\x01user\x01([a-zA-Z0-9]*)\x01([^\x01]*)\x01/;
+const USER_INSERT_REGEX = /\x01user\x01([a-zA-Z0-9_.-]*)\x01([^\x01]*)\x01/;
 const ID_USER_INSERT_REGEX = 1;
 const NAME_USER_INSERT_REGEX = 2;
 
-const CHAN_INSERT_REGEX = /\x01chan\x01([a-zA-Z0-9]*)\x01([^\x01]*)\x01/;
+const CHAN_INSERT_REGEX = /\x01chan\x01([a-zA-Z0-9_-]*)\x01([^\x01]*)\x01/;
 const ID_CHAN_INSERT_REGEX = 1;
 const NAME_CHAN_INSERT_REGEX = 2;
 
-const USERGROUP_INSERT_REGEX = /\x01usergroup\x01([a-zA-Z0-9]*)\x01([^\x01]*)\x01/;
+const USERGROUP_INSERT_REGEX = /\x01usergroup\x01([a-zA-Z0-9_-]*)\x01([^\x01]*)\x01/;
 const ID_USERGROUP_INSERT_REGEX = 1;
 const NAME_USERGROUP_INSERT_REGEX = 2;
 

--- a/test/test_slackmessageparser.ts
+++ b/test/test_slackmessageparser.ts
@@ -101,8 +101,8 @@ describe("SlackMarkdownParser", () => {
 					};
 				},
 			}} as any;
-			const ret = await markdownParser.parseMarkdown(opts, { slackOnly: false }, "Hey <#blah>!");
-			expect(ret).to.equal("Hey <a href=\"https://matrix.to/#/#_slack_blah:example.org\">Chanblah</a>!");
+			const ret = await markdownParser.parseMarkdown(opts, { slackOnly: false }, "Hey <#blah_ro-om>!");
+			expect(ret).to.equal("Hey <a href=\"https://matrix.to/#/#_slack_blah_ro-om:example.org\">Chanblah_ro-om</a>!");
 		});
 		it("should insert name-only if html disabled", async () => {
 			const opts = { callbacks: {
@@ -154,8 +154,8 @@ describe("SlackMarkdownParser", () => {
 					};
 				},
 			}} as any;
-			const ret = await markdownParser.parseMarkdown(opts, { slackOnly: false }, "Hey <!subteam^blah>!");
-			expect(ret).to.equal("Hey <a href=\"https://matrix.to/#/+_slack_blah:example.org\">Groupblah</a>!");
+			const ret = await markdownParser.parseMarkdown(opts, { slackOnly: false }, "Hey <!subteam^blah_gro-up>!");
+			expect(ret).to.equal("Hey <a href=\"https://matrix.to/#/+_slack_blah_gro-up:example.org\">Groupblah_gro-up</a>!");
 		});
 		it("should set name only, if the mxid is blank", async () => {
 			const opts = { callbacks: {


### PR DESCRIPTION
From Slack documentation:
Channel names can only contain lowercase letters, numbers, hyphens, and underscores, and must be 80 characters or less.

From Slack account settings page:
Usernames must be all lowercase. They cannot be longer than 21 characters and can only contain letters, numbers,
periods, hyphens, and underscores.