### PR TITLE
Add support for blocks as attachments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "matrix-slack-parser",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matrix-slack-parser",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "A parser for matrix and discord messages to each others format",
   "main": "./lib/src/index.js",
   "scripts": {

--- a/src/slackmessageparser.ts
+++ b/src/slackmessageparser.ts
@@ -539,6 +539,9 @@ export class SlackMessageParser {
 					const url = escapeHtml(attachment.image_url);
 					result.formatted_body += `Image: <a href="${url}">${url}</a><br>`;
 				}
+				if (attachment.blocks && attachment.blocks.length > 0) {
+					result.formatted_body += await this.blocksParser.parseBlocks(opts, attachment.blocks);
+				}
 				const footerParts: string[] = [];
 				const footerPartsHtml: string[] = [];
 				if (attachment.footer) {

--- a/src/slacktypes.ts
+++ b/src/slacktypes.ts
@@ -134,6 +134,7 @@ export type AllBlocks = KnownBlock | ISlackBlockRichText | ISlackRichTextSection
 	| ISlackBlockTeam | ISlackBlockCall;
 
 export interface ISlackMessageAttachment extends MessageAttachment {
+	blocks?: AllBlocks[];
 	author_id?: string;
 }
 

--- a/test/test_slackmessageparser.ts
+++ b/test/test_slackmessageparser.ts
@@ -857,5 +857,24 @@ describe("SlackMessageParser", () => {
 			expect(ret.body).to.equal("byebye\n");
 			expect(ret.formatted_body).to.equal("<p><sup>byebye</sup><br></p>");
 		});
+		it("should handle attachments with blocks", async () => {
+			const event = {
+				text: "blocks attached",
+				attachments: [{
+					blocks: [{
+						type: 'section',
+						block_id: '12rD',
+						text: {
+							type: 'mrkdwn',
+							text: '*BOLD*: hello',
+							verbatim: false
+						}
+					}],
+				}],
+			} as any;
+			const ret = await messageParser.FormatMessage({} as any, event);
+			expect(ret.body).to.equal("blocks attached\n---------------------\n");
+			expect(ret.formatted_body).to.equal("blocks attached<br><hr><p><p><strong>BOLD</strong>: hello</p></p>");
+		});
 	});
 });


### PR DESCRIPTION
Apparently it's possible to add blocks as attachments to Slack messages.

This is the most simple implementation I could come up with, though I'm not sure how this plays out for messages with multiple attachments. (e.g. a mix of attached image and blocks etc. but I'm not sure if that's allowed by Slack anyway :man_shrugging: )